### PR TITLE
docs: clarify TEST_ASSETS_PATH values and warn about gitignored assets dir

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,7 +86,7 @@ src/
 
 - Cryptography samples may depend on local files, PEM/PFX assets, passwords, or environment variables.
 - Prefer reproducible configuration paths such as environment variables (for example `TEST_ASSETS_PATH`) over hardcoded machine-specific values.
-- Test assets are generated from scripts (for example `scripts/openssl-generate.sh`) and CI sets `TEST_ASSETS_PATH` to `assets`; keep this flow intact.
+- Test assets are generated from scripts (for example `scripts/openssl-generate.sh`) and CI sets `TEST_ASSETS_PATH` to `${{ github.workspace }}/assets`; keep this flow intact.
 - Never add real private keys, credentials, passwords, or machine-specific settings to tracked files.
 - If sample secrets are required for learning, use clearly fake placeholders and document intended injection points.
 
@@ -101,7 +101,7 @@ src/
 ## Dev Container Assumptions
 
 - This repository is developed primarily in a dev container with .NET SDK and common CLI tools preinstalled.
-- Dev container sets `TEST_ASSETS_PATH` to the workspace `assets` directory and installs xunit.v3 templates in post-create; avoid changes that break this setup.
+- Dev container sets `TEST_ASSETS_PATH` to `/workspaces/${localWorkspaceFolderBasename}/assets` and installs xunit.v3 templates in post-create; avoid changes that break this setup.
 - OpenSSL-based fixtures or external test assets may vary by host/container setup.
 - When adding or changing environment-dependent code or tests, preserve behavior that still works in a default container setup.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The script generates development-only assets such as the following:
 - PKCS#7, PKCS#8, and PKCS#12 sample files
 - `.password` used for encrypted PKCS files
 
+> [!CAUTION]
+> The `assets/` directory contains generated development artifacts, including private keys, certificates, and `.password` files.
+> It is gitignored and must not be tracked or committed to the repository.
+
 Inspect generated files with OpenSSL:
 
 ```shell


### PR DESCRIPTION
## Summary

Addresses Copilot review comments posted on #35 after merge.

## Changes

- **`.github/copilot-instructions.md`**
  - Fix ambiguous `assets` (relative path) → explicit `${{ github.workspace }}/assets` in the CI note under *Configuration and Secrets*
  - Fix ambiguous `the workspace assets directory` → explicit `/workspaces/${localWorkspaceFolderBasename}/assets` in the *Dev Container Assumptions* section
- **`README.md`**
  - Add `[!CAUTION]` block after the list of generated assets, warning that `assets/` is gitignored and must not be tracked or committed